### PR TITLE
replace runtime for debug too, added script for building many configs

### DIFF
--- a/CMake/CMakeLists.txt
+++ b/CMake/CMakeLists.txt
@@ -33,6 +33,7 @@ if(MSVC AND CONAN_LINK_RUNTIME)
 
 	foreach(variable ${variables})
 		if(${variable} MATCHES "/MD")
+			string(REGEX REPLACE "/MDd" ${CONAN_LINK_RUNTIME} ${variable} "${${variable}}")
 			string(REGEX REPLACE "/MD" ${CONAN_LINK_RUNTIME} ${variable} "${${variable}}")
 		endif()
 	endforeach()

--- a/build.py
+++ b/build.py
@@ -1,0 +1,29 @@
+import os, sys
+import platform
+
+
+def system(command):
+    retcode = os.system(command)
+    if retcode != 0:
+        raise Exception("Error while executing:\n\t %s" % command)
+
+
+if __name__ == "__main__":
+    system('conan export Kaosumaru/stable')
+    params = " ".join(sys.argv[1:])
+
+    if platform.system() == "Windows":
+        for version in ["14", "12"]:
+            system('conan test -s compiler="Visual Studio" -s compiler.version=%s -s build_type=Release '
+                              '-s compiler.runtime=MD %s' % (version, params))
+            system('conan test -s compiler="Visual Studio" -s compiler.version=%s -s build_type=Release '
+                              '-s compiler.runtime=MT %s' % (version, params))
+            system('conan test -s compiler="Visual Studio" -s compiler.version=%s -s build_type=Debug '
+                              '-s compiler.runtime=MTd %s' % (version, params))  
+            system('conan test -s compiler="Visual Studio" -s compiler.version=%s -s build_type=Debug '
+                              '-s compiler.runtime=MDd %s' % (version, params))
+
+    else:
+        # Not implemented yet, can build many gcc versions with some work
+        system('conan test -s compiler="gcc" -s build_type=Debug')
+        system('conan test -s compiler="gcc" -s build_type=Release')


### PR DESCRIPTION
Thanks for the fix, works fine, but it failed for debug configurations. I have added a line that seems to fix it. I have also added a python script to build many configurations, which I find useful to test things, but I can remove it if you don't like it, no problems.
